### PR TITLE
Add EMAIL environmental varialbe

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ const getCurrentUser = () =>
  */
 const getCurrentUserMail = () =>
   workspace.getConfiguration()
-    .get('42header.email') || `${getCurrentUser()}@student.42.fr`
+    .get('42header.email') || process.env['EMAIL'] || `${getCurrentUser()}@student.42.fr`
 
 /**
  * Update HeaderInfo with last update author and date, and update filename


### PR DESCRIPTION
Add environmental variable EMAIL to allow using external environmental variables.

This allow the use of docker .env files to use the extension during building for the container.  Specifically vscode development containers.